### PR TITLE
feat(schema/zod): implement VerifyEmailRegisterRequestBody schema zod

### DIFF
--- a/src/__tests__/sendErrorResponse.test.ts
+++ b/src/__tests__/sendErrorResponse.test.ts
@@ -161,7 +161,7 @@ describe('sendErrorResponse', () => {
           details: expect.objectContaining({
             _errors: [],
             email: {
-              _errors: [ValidationMessages.userAuth.EMAIL_REQUIRED]
+              _errors: [ValidationMessages.api.request.auth.local.register.EMAIL_REQUIRED]
             }
           })
         })

--- a/src/constants/validationMessages.constant.ts
+++ b/src/constants/validationMessages.constant.ts
@@ -1,4 +1,23 @@
 export const ValidationMessages = {
+  api: {
+    request: {
+      auth: {
+        local: {
+          register: {
+            EMAIL_REQUIRED: 'Email is required',
+            EMAIL_INVALID: 'Email invalid'
+          },
+          verifyEmailRegister: {
+            EMAIL_REQUIRED: 'Email is required',
+            EMAIL_INVALID: 'Email invalid',
+            OTP_REQUIRED: 'OTP Required',
+            OTP_MAX_LENGTH: 'Max length OTP is',
+            OTP_INVALID: 'OTP invalid'
+          }
+        }
+      }
+    }
+  },
   userAuth: {
     INVALID_EMAIL: 'Email invalid',
     WEAK_PASSWORD: 'Password must include at last one lowercase, uppercase, and number',

--- a/src/schema/zod/api/requests/auth/local.schema.ts
+++ b/src/schema/zod/api/requests/auth/local.schema.ts
@@ -1,14 +1,39 @@
 import { z } from 'zod';
 import { ValidationMessages } from '../../../../../constants/validationMessages.constant.js';
 
-const { EMAIL_REQUIRED, INVALID_EMAIL } = ValidationMessages.userAuth;
+const { EMAIL_REQUIRED: EMAIL_REQUIRED_REGISTER, EMAIL_INVALID: EMAIL_INVALID_REGISTER } =
+  ValidationMessages.api.request.auth.local.register;
+
+const {
+  EMAIL_INVALID: EMAIL_INVALID_VERIFY,
+  EMAIL_REQUIRED: EMAIL_REQUIRED_VERIFY,
+  OTP_MAX_LENGTH: OTP_MAX_LENGTH_VERIFY,
+  OTP_REQUIRED: OTP_REQUIRED_VERIFY,
+  OTP_INVALID: OTP_INVALID_VERIFY
+} = ValidationMessages.api.request.auth.local.verifyEmailRegister;
 
 export const registerLocalRequestBodySchema = z.object({
   email: z
     .string({
-      required_error: EMAIL_REQUIRED
+      required_error: EMAIL_REQUIRED_REGISTER
     })
-    .email(INVALID_EMAIL)
+    .email(EMAIL_INVALID_REGISTER)
+});
+
+export const verifyEmailRegisterRequestBodySchema = z.object({
+  email: z
+    .string({
+      required_error: EMAIL_REQUIRED_VERIFY
+    })
+    .email(EMAIL_INVALID_VERIFY),
+
+  otp: z
+    .number({
+      required_error: OTP_REQUIRED_VERIFY,
+      invalid_type_error: OTP_INVALID_VERIFY
+    })
+    .max(6, OTP_MAX_LENGTH_VERIFY)
 });
 
 export type RegisterLocalRequestBody = z.infer<typeof registerLocalRequestBodySchema>;
+export type VerifyEmailRegisterRequestBody = z.infer<typeof verifyEmailRegisterRequestBodySchema>;


### PR DESCRIPTION
Define a Zod schema to validate the request body for the "verify email after registration" endpoint.

Closes #80