### PR TITLE
feat(ioredis.service.ts): implement method removePinCodeVerifyEmail

### DIFF
--- a/src/services/Ioredis.service.ts
+++ b/src/services/Ioredis.service.ts
@@ -11,6 +11,10 @@ type GetPinCodeVerifyEmailParams = {
   email: string;
 };
 
+type RemovePinCodeVerifyEmailParams = {
+  email: string;
+};
+
 type SavePinCodeVerifyEmailResponse = {
   expiredTimeAtPinCode: number;
 };
@@ -69,5 +73,10 @@ export class IoredisService implements IIoredisService {
     const key = RedisKeyGenerator.pinCodeVerifyEmail({ email });
     const data = await this._redisInstance.get(key);
     return data;
+  }
+
+  public async removePinCodeVerifyEmail({ email }: RemovePinCodeVerifyEmailParams): Promise<void> {
+    const key = RedisKeyGenerator.pinCodeVerifyEmail({ email });
+    await this._redisInstance.del(key);
   }
 }


### PR DESCRIPTION
Implement a service method to remove the pin code used for verifying the user's email address after it has been successfully verified.

Closes #82 