### PR TITLE
feat(constants-services-utils): implement methods interact with whitelist refreshToken in redis

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["jwtid", "setex", "virtuals", "zalo"]
+  "cSpell.words": ["jwtid", "sadd", "setex", "sismember", "srem", "virtuals", "zalo"]
 }

--- a/src/constants/redisKeys.constant.ts
+++ b/src/constants/redisKeys.constant.ts
@@ -1,3 +1,7 @@
-export enum RedisKeys {
-  PIN_CODE_VERIFY_EMAIL = 'register:verifyEmail'
-}
+export const RedisKeys = {
+  PIN_CODE_VERIFY_EMAIL: 'register:verifyEmail',
+  REFRESH_TOKEN_WHITELIST: 'refreshToken_whitelist'
+} as const;
+
+export type RedisKeysKeys = keyof typeof RedisKeys;
+export type RedisKeysValues = (typeof RedisKeys)[RedisKeysKeys];

--- a/src/utils/RedisKeyGenerator.util.ts
+++ b/src/utils/RedisKeyGenerator.util.ts
@@ -4,6 +4,10 @@ type PinCodeVerifyEmailParams = {
   email: string;
 };
 
+type RefreshTokenWhitelistParams = {
+  userAuthId: string;
+};
+
 export class RedisKeyGenerator {
   /**
    * Generates a Redis key specifically for storing or retrieving PIN codes
@@ -25,5 +29,9 @@ export class RedisKeyGenerator {
   static pinCodeVerifyEmail(params: PinCodeVerifyEmailParams): string {
     const { email } = params;
     return `${RedisKeys.PIN_CODE_VERIFY_EMAIL}:${email}`;
+  }
+
+  static refreshTokenWhitelist({ userAuthId }: RefreshTokenWhitelistParams): string {
+    return `${RedisKeys.REFRESH_TOKEN_WHITELIST}:${userAuthId}`;
   }
 }


### PR DESCRIPTION
Implement a set of methods in a Redis service to interact with the refresh token whitelist. These methods will be used to store, retrieve, and remove valid refresh tokens associated with a user or session.

Closes #104