### PR TITLE
feat(src): implement api upload image logo brand

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import morgan from 'morgan';
 import { ErrorMiddlewareHandler } from './middleware/errorHandler.middleware.js';
 import { router as authRouter } from './routes/auth/index.route.js';
 import { router as userProfileRouter } from './routes/userProfile.routes.js';
+import { router as uploadRouter } from './routes/upload/index.routes.js';
 
 const app = express();
 
@@ -13,6 +14,7 @@ app.use(morgan('dev'));
 // Initial routes
 app.use('/auth', authRouter);
 app.use('/profile', userProfileRouter);
+app.use('/upload', uploadRouter);
 
 app.use(ErrorMiddlewareHandler.handler.bind(ErrorMiddlewareHandler));
 

--- a/src/controllers/upload/image.controller.ts
+++ b/src/controllers/upload/image.controller.ts
@@ -1,0 +1,35 @@
+import { NextFunction, Request, Response } from 'express';
+import { UploadImageService } from '../../services/UploadImage.service';
+import { sendSuccessResponse } from '../../utils/responses.util.js';
+import { StatusCodes } from 'http-status-codes';
+
+interface IUploadImageController {
+  logoBrand: (request: Request, response: Response, next: NextFunction) => Promise<void>;
+}
+
+export class UploadImageController implements IUploadImageController {
+  private _uploadImageService: UploadImageService = new UploadImageService();
+
+  constructor() {}
+
+  public async logoBrand(request: Request, response: Response) {
+    const file = request.file as Express.Multer.File;
+
+    const { publicId, url } = await this._uploadImageService.logoBrand({
+      fileBuffer: file.buffer,
+      originalFileName: file.originalname
+    });
+
+    sendSuccessResponse<{ publicId: string; url: string }>({
+      response,
+      content: {
+        statusCode: StatusCodes.OK,
+        message: 'Upload logo brand success',
+        data: {
+          publicId,
+          url
+        }
+      }
+    });
+  }
+}

--- a/src/enums/cloudinaryFolder.enum.ts
+++ b/src/enums/cloudinaryFolder.enum.ts
@@ -1,3 +1,4 @@
 export enum CloudinaryFolder {
-  USER_AVATAR = 'user_avatar'
+  USER_AVATAR = 'user_avatar',
+  LOGO_BRAND = 'logo_brand'
 }

--- a/src/routes/upload/image.routes.ts
+++ b/src/routes/upload/image.routes.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { UploadImageController } from '../../controllers/upload/image.controller.js';
+import { verifyAccessTokenMiddleware } from '../../middleware/verifyAccessToken.middleware.js';
+import { UploadMulterMiddleware } from '../../middleware/UploadMulter.middleware.js';
+
+export const router = Router();
+
+const uploadImageController = new UploadImageController();
+const uploadImageLogoBrandMulterMiddleware = new UploadMulterMiddleware({ fieldName: 'logo' });
+
+router.post(
+  '/brand/logo',
+  verifyAccessTokenMiddleware,
+  uploadImageLogoBrandMulterMiddleware.singleUpload.bind(uploadImageLogoBrandMulterMiddleware),
+  uploadImageController.logoBrand.bind(uploadImageController)
+);

--- a/src/routes/upload/index.routes.ts
+++ b/src/routes/upload/index.routes.ts
@@ -1,0 +1,6 @@
+import { Router } from 'express';
+import { router as imageRouter } from './image.routes.js';
+
+export const router = Router();
+
+router.use('/image', imageRouter);

--- a/src/services/UploadImage.service.ts
+++ b/src/services/UploadImage.service.ts
@@ -1,0 +1,31 @@
+import { CloudinaryFolder } from '../enums/cloudinaryFolder.enum.js';
+import { CloudinaryService } from './external/Cloudinary.service.js';
+
+type LogoBrandParams = {
+  fileBuffer: Buffer;
+  originalFileName: string;
+};
+
+interface IUploadImageService {
+  logoBrand: (params: LogoBrandParams) => Promise<{
+    publicId: string;
+    url: string;
+  }>;
+}
+
+export class UploadImageService implements IUploadImageService {
+  constructor() {}
+
+  public async logoBrand({ fileBuffer, originalFileName }: LogoBrandParams): Promise<{
+    publicId: string;
+    url: string;
+  }> {
+    const cloudinaryService = new CloudinaryService(CloudinaryFolder.LOGO_BRAND);
+    const { url, public_id } = await cloudinaryService.uploadStream(fileBuffer, originalFileName);
+
+    return {
+      url,
+      publicId: public_id
+    };
+  }
+}


### PR DESCRIPTION
Implement an API endpoint that allows uploading an image to be used as a logo for a brand. This will store the image in Cloudinary (or any cloud service) and return the secure URL.

Closes #186