### PR TITLE
feat(src): implement api delete image banner brand

### DIFF
--- a/src/controllers/upload/image.controller.ts
+++ b/src/controllers/upload/image.controller.ts
@@ -5,11 +5,13 @@ import { sendSuccessResponse } from '../../utils/responses.util.js';
 import { CloudinaryFolder } from 'src/enums/cloudinaryFolder.enum.js';
 
 type DeleteLogoBrandRequestType = Request<{ public_id: string }, unknown, unknown>;
+type DeleteBannerBrandRequestType = Request<{ public_id: string }>;
 
 interface IUploadImageController {
   uploadLogoBrand: (request: Request, response: Response, next: NextFunction) => Promise<void>;
   deleteLogoBrand: (request: DeleteLogoBrandRequestType, response: Response, next: NextFunction) => Promise<void>;
   uploadBannerBrand: (request: Request, response: Response, next: NextFunction) => Promise<void>;
+  deleteBannerBrand: (request: DeleteBannerBrandRequestType, response: Response, next: NextFunction) => Promise<void>;
 }
 
 export class UploadImageController implements IUploadImageController {
@@ -40,7 +42,7 @@ export class UploadImageController implements IUploadImageController {
 
   public async deleteLogoBrand(request: DeleteLogoBrandRequestType, response: Response): Promise<void> {
     const { public_id } = request.params;
-    await this._uploadImageService.deleteLogoBrand({ publicId: `${CloudinaryFolder.LOGOS_BRAND}/${public_id}` });
+    await this._uploadImageService.deleteLogoBrand({ publicId: public_id });
 
     sendSuccessResponse<{ publicId: string }>({
       response,
@@ -73,6 +75,22 @@ export class UploadImageController implements IUploadImageController {
         data: {
           publicId,
           url
+        }
+      }
+    });
+  }
+
+  public async deleteBannerBrand(request: DeleteBannerBrandRequestType, response: Response): Promise<void> {
+    const { public_id } = request.params;
+    await this._uploadImageService.deleteBannerBrand({ publicId: public_id });
+
+    sendSuccessResponse<{ publicId: string }>({
+      response,
+      content: {
+        statusCode: StatusCodes.OK,
+        message: 'Delete image banner brand success',
+        data: {
+          publicId: `${CloudinaryFolder.BANNERS_BRAND}/${public_id}`
         }
       }
     });

--- a/src/routes/upload/image.routes.ts
+++ b/src/routes/upload/image.routes.ts
@@ -18,11 +18,21 @@ router.post(
   uploadImageController.uploadLogoBrand.bind(uploadImageController)
 );
 
-router.delete('/brand/logo/:public_id', uploadImageController.deleteLogoBrand.bind(uploadImageController));
+router.delete(
+  '/brand/logo/:public_id',
+  verifyAccessTokenMiddleware,
+  uploadImageController.deleteLogoBrand.bind(uploadImageController)
+);
 
 router.post(
   '/brand/banner',
   verifyAccessTokenMiddleware,
   uploadImageBannerBrandMulterMiddleware.singleUpload.bind(uploadImageBannerBrandMulterMiddleware),
   uploadImageController.uploadBannerBrand.bind(uploadImageController)
+);
+
+router.delete(
+  '/brand/banner/:public_id',
+  verifyAccessTokenMiddleware,
+  uploadImageController.deleteBannerBrand.bind(uploadImageController)
 );

--- a/src/services/UploadImage.service.ts
+++ b/src/services/UploadImage.service.ts
@@ -11,6 +11,10 @@ type UploadBannerBrandParams = {
   originalFileName: string;
 };
 
+type DeleteBannerBrandParams = {
+  publicId: string;
+};
+
 type DeleteLogoBrandParams = {
   publicId: string;
 };
@@ -27,6 +31,8 @@ interface IUploadImageService {
     publicId: string;
     url: string;
   }>;
+
+  deleteBannerBrand: (params: DeleteBannerBrandParams) => Promise<void>;
 }
 
 export class UploadImageService implements IUploadImageService {
@@ -47,7 +53,7 @@ export class UploadImageService implements IUploadImageService {
 
   public async deleteLogoBrand({ publicId }: DeleteLogoBrandParams): Promise<void> {
     const cloudinaryService = new CloudinaryService(CloudinaryFolder.LOGOS_BRAND);
-    await cloudinaryService.delete({ publicId });
+    await cloudinaryService.delete({ publicId: `${CloudinaryFolder.BANNERS_BRAND}/${publicId}` });
 
     return;
   }
@@ -63,5 +69,11 @@ export class UploadImageService implements IUploadImageService {
       publicId: public_id,
       url
     };
+  }
+
+  public async deleteBannerBrand({ publicId }: DeleteBannerBrandParams): Promise<void> {
+    const cloudinaryService = new CloudinaryService(CloudinaryFolder.BANNERS_BRAND);
+    await cloudinaryService.delete({ publicId: `${CloudinaryFolder.BANNERS_BRAND}/${publicId}` });
+    return;
   }
 }


### PR DESCRIPTION
Implement an API endpoint to delete a banner image of a brand from the cloud storage (e.g., Cloudinary) using its public_id.

Closes #189