### PR TITLE
Feat/211 implement option get tree data category

### DIFF
--- a/src/constants/validationMessages.constant.ts
+++ b/src/constants/validationMessages.constant.ts
@@ -102,6 +102,7 @@ export const ValidationMessages = {
 
   category: {
     NAME_REQUIRED: 'Name category is required',
-    SLUG_REQUIRED: 'Slug category is required'
+    SLUG_REQUIRED: 'Slug category is required',
+    ORDER_REQUIRED: 'Order category is required'
   }
 };

--- a/src/controllers/Category.controller.ts
+++ b/src/controllers/Category.controller.ts
@@ -37,6 +37,7 @@ interface ICategoryController {
   getDetails: (request: GetDetailsRequestType, response: Response, next: NextFunction) => Promise<void>;
   getAll: (request: GetAllRequestType, response: Response, next: NextFunction) => Promise<void>;
   changeParentId: (request: ChangeParentIdRequestType, response: Response, next: NextFunction) => Promise<void>;
+  getAllTree: (request: Request, response: Response, next: NextFunction) => Promise<void>;
 }
 
 const DEFAULT_PARENT_ID_GET_ALL = null;
@@ -132,6 +133,18 @@ export class CategoryController implements ICategoryController {
       content: {
         statusCode: StatusCodes.NO_CONTENT,
         message: 'Update new parent for category success'
+      }
+    });
+  }
+
+  public async getAllTree(_: Request, response: Response): Promise<void> {
+    const data = await this._categoryService.getAllTree();
+    sendSuccessResponse<typeof data>({
+      response,
+      content: {
+        statusCode: StatusCodes.OK,
+        message: 'Get all categories tree success',
+        data: data
       }
     });
   }

--- a/src/models/category.model.ts
+++ b/src/models/category.model.ts
@@ -1,4 +1,4 @@
-import { Document, model, Schema } from 'mongoose';
+import { Document, model, Schema, Types } from 'mongoose';
 import { CategorySchemaType } from '../schema/zod/category/index.schema.js';
 
 const DOCUMENT_NAME = 'category';
@@ -13,7 +13,8 @@ const categorySchema = new Schema<ICategoryDocument>(
       required: true
     },
     parentId: {
-      type: String,
+      type: Types.ObjectId,
+      ref: DOCUMENT_NAME,
       default: null
     },
     slug: {
@@ -23,6 +24,10 @@ const categorySchema = new Schema<ICategoryDocument>(
     hasChildren: {
       type: Boolean,
       default: false
+    },
+    order: {
+      type: Number,
+      required: true
     }
   },
   {

--- a/src/repositories/Category.repository.ts
+++ b/src/repositories/Category.repository.ts
@@ -38,6 +38,8 @@ type UpdateByDocParams = {
   updateData: UpdateQuery<ICategoryDocument>;
 };
 
+type GetAllTreeReturns = ICategoryDocument[];
+
 interface ICategoryRepository {
   create: (params: CreateParams) => Promise<ICategoryDocument>;
   deleteById: (params: DeleteParams) => Promise<ICategoryDocument | null>;
@@ -50,6 +52,7 @@ interface ICategoryRepository {
   checkHasChildCategories: (params: CheckHasChildCategories) => Promise<boolean>;
   updateManyParentId: (params: UpdateManyParentIdParams) => Promise<void>;
   updateByDoc: (params: UpdateByDocParams) => Promise<ICategoryDocument>;
+  getAllTree: () => Promise<GetAllTreeReturns>;
 }
 
 export class CategoryRepository implements ICategoryRepository {
@@ -116,5 +119,9 @@ export class CategoryRepository implements ICategoryRepository {
     return await categoryDoc.updateOne(updateData, {
       new: true
     });
+  }
+
+  async getAllTree(): Promise<GetAllTreeReturns> {
+    return await this._categoryModel.find().lean();
   }
 }

--- a/src/routes/category.route.ts
+++ b/src/routes/category.route.ts
@@ -37,6 +37,7 @@ router.patch(
   categoryController.update.bind(categoryController)
 );
 
+router.get('/tree', categoryController.getAllTree.bind(categoryController));
 router.get('/:id', categoryController.getDetails.bind(categoryController));
 router.get('/', categoryController.getAll.bind(categoryController));
 router.patch(

--- a/src/schema/zod/api/requests/category.schema.ts
+++ b/src/schema/zod/api/requests/category.schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { nameSchema, parentIdSchema, slugSchema } from '../../category/field.schema.js';
+import { nameSchema, orderSchema, parentIdSchema, slugSchema } from '../../category/field.schema.js';
 import { ValidationMessages } from 'src/constants/validationMessages.constant.js';
 
 const { PARENT_ID_REQUIRED } = ValidationMessages.api.request.category.changeParentId;
@@ -7,13 +7,15 @@ const { PARENT_ID_REQUIRED } = ValidationMessages.api.request.category.changePar
 export const createCategoryRequestBodySchema = z.object({
   name: nameSchema,
   parentId: parentIdSchema.nullable(),
-  slug: slugSchema
+  slug: slugSchema,
+  order: orderSchema
 });
 
 export const updateCategoryRequestBodySchema = z.object({
   name: nameSchema.optional(),
   parentId: parentIdSchema.optional(),
-  slug: slugSchema.optional()
+  slug: slugSchema.optional(),
+  order: orderSchema.optional()
 });
 
 export const changeParentIdRequestBodySchema = z.object({

--- a/src/schema/zod/category/field.schema.ts
+++ b/src/schema/zod/category/field.schema.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod';
 import { ValidationMessages } from '../../../constants/validationMessages.constant.js';
 
-const { SLUG_REQUIRED, NAME_REQUIRED } = ValidationMessages.category;
+const { SLUG_REQUIRED, NAME_REQUIRED, ORDER_REQUIRED } = ValidationMessages.category;
 
 export const nameSchema = z.string({ required_error: NAME_REQUIRED });
 export const slugSchema = z.string({ required_error: SLUG_REQUIRED });
 export const hasChildrenSchema = z.boolean();
+export const orderSchema = z.number({ required_error: ORDER_REQUIRED });
 export const parentIdSchema = z.string();

--- a/src/schema/zod/category/index.schema.ts
+++ b/src/schema/zod/category/index.schema.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod';
-import { hasChildrenSchema, nameSchema, parentIdSchema, slugSchema } from './field.schema.js';
+import { hasChildrenSchema, nameSchema, orderSchema, parentIdSchema, slugSchema } from './field.schema.js';
 
 export const categoryZodSchema = z.object({
   parentId: parentIdSchema.nullable(),
   name: nameSchema,
   slug: slugSchema,
-  hasChildren: hasChildrenSchema.default(false)
+  hasChildren: hasChildrenSchema.default(false),
+  order: orderSchema
 });
 
 export type CategorySchemaType = z.infer<typeof categoryZodSchema>;

--- a/src/utils/buildTree.util.ts
+++ b/src/utils/buildTree.util.ts
@@ -1,0 +1,96 @@
+type KeyOfObject<T extends object> = keyof T;
+
+type TreeNode<T> = T & {
+  children?: TreeNode<T>[];
+};
+
+export const buildTree = <T extends object & { children?: T[] }>(
+  flatList: T[],
+  idField: KeyOfObject<T>,
+  parentIdField: KeyOfObject<T>
+): TreeNode<T>[] => {
+  const map = new Map();
+  const tree: TreeNode<T>[] = [];
+
+  for (const node of flatList) {
+    if (!node.children) {
+      node.children = [];
+      map.set(String(node[idField]), node);
+    }
+  }
+
+  for (const node of flatList) {
+    const parentId = String(node[parentIdField]);
+    if (parentId !== 'null') {
+      const parentNode = map.get(parentId) as T | null;
+      if (parentNode) {
+        parentNode.children!.push(node);
+        continue;
+      }
+    }
+
+    tree.push(node);
+  }
+
+  return tree as TreeNode<T>[];
+};
+
+export class BuildTree<T extends object & { children?: T[] }> {
+  private _flatList: T[];
+  private _idFiled: KeyOfObject<T>;
+  private _parentIdField: KeyOfObject<T>;
+  private _map = new Map();
+  private _tree: TreeNode<T>[] = [];
+
+  constructor(flatList: T[], idField: KeyOfObject<T>, parentIdField: KeyOfObject<T>) {
+    this._flatList = flatList;
+    this._idFiled = idField;
+    this._parentIdField = parentIdField;
+  }
+
+  private _nodeWithChildren() {
+    for (const node of this._flatList) {
+      node.children = [];
+
+      this._map.set(String(node[this._idFiled]), node);
+    }
+  }
+
+  private _nodeWithTree() {
+    for (const node of this._flatList) {
+      const parentId = String(node[this._parentIdField]);
+      if (parentId !== 'null') {
+        const parentNode = this._map.get(parentId) as T;
+        if (parentNode) {
+          parentNode.children!.push(node);
+          continue;
+        }
+      }
+
+      this._tree.push(node);
+    }
+  }
+
+  public sortTree(nodes: TreeNode<T>[], keySort: KeyOfObject<T>) {
+    nodes.sort((a, b) => {
+      if (a[keySort] > b[keySort]) return 1;
+      if (a[keySort] < b[keySort]) return -1;
+      return 0;
+    });
+
+    for (const node of nodes) {
+      if (node.children && node.children.length > 0) {
+        this.sortTree(node.children, keySort);
+      }
+    }
+
+    return this._tree;
+  }
+
+  public getTree() {
+    this._nodeWithChildren();
+    this._nodeWithTree();
+
+    return this._tree;
+  }
+}


### PR DESCRIPTION
Build an API or extend existing category endpoint to return category data in a tree structure, allowing the frontend to render nested categories easily (e.g., for a sidebar or product filter UI).

Closes: #211 