### PR TITLE
feat(src): implement api upload banner for brand

### DIFF
--- a/src/constants/validationMessages.constant.ts
+++ b/src/constants/validationMessages.constant.ts
@@ -76,6 +76,9 @@ export const ValidationMessages = {
           },
           uploadBrandLogo: {
             NAME_BRAND_REQUIRED: 'Name brand is required'
+          },
+          uploadBannerBrand: {
+            NAME_BRAND_REQUIRED: 'Name brand is required'
           }
         }
       }

--- a/src/controllers/external/cloudinary/BrandCloudinary.controller.ts
+++ b/src/controllers/external/cloudinary/BrandCloudinary.controller.ts
@@ -6,11 +6,14 @@ import { CloudinaryService } from '../../../services/external/Cloudinary.service
 import { CloudinaryFolder } from '../../../enums/cloudinaryFolder.enum.js';
 import { sendSuccessResponse } from '../../../utils/responses.util.js';
 import { StatusCodes } from 'http-status-codes';
+import { UploadBannerDTO as BrandUploadBannerDTO } from '../../../dto/request/external/cloudinary/brand/uploadBanner.dto.js';
 
 type UploadLogoRequestType = Request<unknown, unknown, BrandUploadLogoDTO>;
+type UploadBannerRequestType = Request<unknown, unknown, BrandUploadBannerDTO>;
 
 interface IBrandCloudinaryController {
   uploadLogo: (request: UploadLogoRequestType, response: Response, next: NextFunction) => Promise<void>;
+  uploadBanner: (request: UploadBannerRequestType, response: Response, next: NextFunction) => Promise<void>;
 }
 
 export class BrandCloudinaryController implements IBrandCloudinaryController {
@@ -25,7 +28,7 @@ export class BrandCloudinaryController implements IBrandCloudinaryController {
       fileBuffer: file.buffer,
       originalFileName: file.originalname,
       needSuffix: true,
-      remainingPathDirectory: `/${nameBrand}/logo`
+      remainingPathDirectory: `/${nameBrand}/logos`
     });
 
     const responseData = BrandCloudinaryResponseDTO.uploadLogo(uploadResponse);
@@ -35,6 +38,30 @@ export class BrandCloudinaryController implements IBrandCloudinaryController {
       content: {
         statusCode: StatusCodes.OK,
         message: 'Upload logo brand success',
+        data: responseData
+      }
+    });
+  }
+
+  public async uploadBanner(request: UploadBannerRequestType, response: Response): Promise<void> {
+    const file = request.file as Express.Multer.File;
+    const { nameBrand } = BrandCloudinaryRequestDTO.uploadBanner(request.body);
+
+    const cloudinaryService = new CloudinaryService(CloudinaryFolder.BRAND);
+    const uploadResponse = await cloudinaryService.uploadStream({
+      fileBuffer: file.buffer,
+      originalFileName: file.originalname,
+      remainingPathDirectory: `/${nameBrand}/banners`,
+      needSuffix: true,
+      isOverwrite: false
+    });
+
+    const responseData = BrandCloudinaryResponseDTO.uploadBanner(uploadResponse);
+    sendSuccessResponse<typeof responseData>({
+      response,
+      content: {
+        statusCode: StatusCodes.OK,
+        message: 'Upload banner for brand success',
         data: responseData
       }
     });

--- a/src/dto/request/external/cloudinary/brand/index.dto.ts
+++ b/src/dto/request/external/cloudinary/brand/index.dto.ts
@@ -1,9 +1,14 @@
 import { uploadLogoDTO, UploadLogoDTO } from './uploadLogo.dto.js';
+import { uploadBannerDTO, UploadBannerDTO } from './uploadBanner.dto.js';
 
 export class BrandCloudinaryRequestDTO {
   constructor() {}
 
   static uploadLogo(data: UploadLogoDTO): UploadLogoDTO {
     return uploadLogoDTO.parse(data);
+  }
+
+  static uploadBanner(data: UploadBannerDTO): UploadLogoDTO {
+    return uploadBannerDTO.parse(data);
   }
 }

--- a/src/dto/request/external/cloudinary/brand/uploadBanner.dto.ts
+++ b/src/dto/request/external/cloudinary/brand/uploadBanner.dto.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+import { ValidationMessages } from '../../../../../constants/validationMessages.constant.js';
+
+const { NAME_BRAND_REQUIRED } = ValidationMessages.api.request.external.cloudinary.uploadBannerBrand;
+
+export const uploadBannerDTO = z.object({
+  nameBrand: z.string({ required_error: NAME_BRAND_REQUIRED })
+});
+
+export type UploadBannerDTO = z.infer<typeof uploadBannerDTO>;

--- a/src/dto/response/external/cloudinary/brand/index.dto.ts
+++ b/src/dto/response/external/cloudinary/brand/index.dto.ts
@@ -1,4 +1,5 @@
 import { uploadLogoDTO, UploadLogoDTO } from './uploadLogo.dto.js';
+import { uploadBannerDTO, UploadBannerDTO } from './uploadBanner.dto.js';
 import { UploadApiResponse } from 'cloudinary';
 
 export class BrandCloudinaryResponseDTO {
@@ -11,5 +12,14 @@ export class BrandCloudinaryResponseDTO {
     };
 
     return uploadLogoDTO.parse(candidate);
+  }
+
+  static uploadBanner(data: UploadApiResponse): UploadBannerDTO {
+    const candidate: UploadBannerDTO = {
+      publicId: data.public_id,
+      url: data.secure_url
+    };
+
+    return uploadBannerDTO.parse(candidate);
   }
 }

--- a/src/dto/response/external/cloudinary/brand/uploadBanner.dto.ts
+++ b/src/dto/response/external/cloudinary/brand/uploadBanner.dto.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const uploadBannerDTO = z.object({
+  url: z.string(),
+  publicId: z.string()
+});
+
+export type UploadBannerDTO = z.infer<typeof uploadBannerDTO>;

--- a/src/routes/external/cloudinary/images/brands.routes.ts
+++ b/src/routes/external/cloudinary/images/brands.routes.ts
@@ -3,6 +3,10 @@ import { UploadMulterMiddleware } from '../../../../middleware/UploadMulter.midd
 import { validateRequestBody } from '../../../../middleware/validateRequestBody.middleware.js';
 import { uploadLogoDTO, UploadLogoDTO } from '../../../../dto/request/external/cloudinary/brand/uploadLogo.dto.js';
 import { BrandCloudinaryController } from '../../../../controllers/external/cloudinary/BrandCloudinary.controller.js';
+import {
+  uploadBannerDTO,
+  UploadBannerDTO
+} from '../../../../dto/request/external/cloudinary/brand/uploadBanner.dto.js';
 
 export const router = Router();
 
@@ -10,13 +14,22 @@ const brandCloudinaryController = new BrandCloudinaryController();
 
 // Middleware requestBody
 const uploadLogoMulterMiddleware = new UploadMulterMiddleware({ fieldName: 'logo' });
+const uploadBannerMulterMiddleware = new UploadMulterMiddleware({ fieldName: 'banner' });
 
 // Middleware validate file upload multer
 const validateRequestBodyUploadLogo = validateRequestBody<UploadLogoDTO>(uploadLogoDTO);
+const validateRequestBodyUploadBanner = validateRequestBody<UploadBannerDTO>(uploadBannerDTO);
 
 router.post(
   '/logo/upload/single',
   uploadLogoMulterMiddleware.singleUpload.bind(uploadLogoMulterMiddleware),
   validateRequestBodyUploadLogo,
   brandCloudinaryController.uploadLogo.bind(brandCloudinaryController)
+);
+
+router.post(
+  '/banner/upload/single',
+  uploadBannerMulterMiddleware.singleUpload.bind(uploadBannerMulterMiddleware),
+  validateRequestBodyUploadBanner,
+  brandCloudinaryController.uploadBanner.bind(brandCloudinaryController)
 );


### PR DESCRIPTION
Develop an API that allows uploading one or multiple banner images for a brand to Cloudinary, and return metadata of the uploaded files for preview or save in DB.

Closes #236