### PR TITLE
feat(src): implement api get root folder cloudinary

### DIFF
--- a/src/controllers/external/cloudinary/FolderCloudinary.controller.ts
+++ b/src/controllers/external/cloudinary/FolderCloudinary.controller.ts
@@ -1,0 +1,32 @@
+import { NextFunction, Request, Response } from 'express';
+import { CloudinaryService } from '../../../services/external/Cloudinary.service.js';
+import { sendSuccessResponse } from '../../../utils/responses.util.js';
+import { StatusCodes } from 'http-status-codes';
+import { FolderCloudinaryResponseDTO } from '../../../dto/response/external/cloudinary/folder/index.dto.js';
+
+type GetRootRequestType = Request;
+
+interface IFolderCloudinaryController {
+  getRoot: (request: GetRootRequestType, response: Response, next: NextFunction) => Promise<void>;
+}
+
+export class FolderCloudinaryController implements IFolderCloudinaryController {
+  constructor() {}
+
+  public async getRoot(request: GetRootRequestType, response: Response): Promise<void> {
+    const cloudinaryService = new CloudinaryService('root');
+    const responseCloudinary = await cloudinaryService.getRootFolder();
+
+    const { metadata, data } = FolderCloudinaryResponseDTO.getRootFolder(responseCloudinary);
+
+    sendSuccessResponse<typeof data, typeof metadata>({
+      response,
+      content: {
+        statusCode: StatusCodes.OK,
+        message: 'Get all root folder success',
+        data,
+        metadata
+      }
+    });
+  }
+}

--- a/src/dto/response/external/cloudinary/folder/getRootFolder.dto.ts
+++ b/src/dto/response/external/cloudinary/folder/getRootFolder.dto.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+const folderSchema = z.object({
+  name: z.string(),
+  path: z.string(),
+  externalId: z.string()
+});
+
+export const getRootFolderDTO = z.object({
+  data: z.array(folderSchema),
+  metadata: z.object({
+    nextCursor: z.string().nullable(),
+    totalCount: z.number(),
+    rateLimitAllowed: z.number(),
+    rateLimitResetAt: z.string(),
+    rateLimitRemaining: z.number()
+  })
+});
+
+export type GetRootFolderDTO = z.infer<typeof getRootFolderDTO>;

--- a/src/dto/response/external/cloudinary/folder/index.dto.ts
+++ b/src/dto/response/external/cloudinary/folder/index.dto.ts
@@ -1,0 +1,27 @@
+import { getRootFolderDTO, GetRootFolderDTO } from './getRootFolder.dto.js';
+import { GetRootFoldersResponse } from '../../../../../types/cloudinary.type.js';
+
+export class FolderCloudinaryResponseDTO {
+  constructor() {}
+
+  static getRootFolder(data: GetRootFoldersResponse): GetRootFolderDTO {
+    const folders: GetRootFolderDTO['data'] = data.folders.map((folder) => ({
+      name: folder.name,
+      path: folder.path,
+      externalId: folder.external_id
+    }));
+    const timeFormat = new Date(data.rate_limit_reset_at!).toISOString();
+    const candidate: GetRootFolderDTO = {
+      data: folders,
+      metadata: {
+        nextCursor: data!.next_cursor!,
+        totalCount: data!.total_count!,
+        rateLimitAllowed: data.rate_limit_allowed!,
+        rateLimitRemaining: data.rate_limit_remaining!,
+        rateLimitResetAt: timeFormat
+      }
+    };
+
+    return getRootFolderDTO.parse(candidate);
+  }
+}

--- a/src/routes/auth/local.route.ts
+++ b/src/routes/auth/local.route.ts
@@ -6,8 +6,6 @@ import {
   forgotPasswordRequestBodySchema,
   LoginRequestBody,
   loginRequestBodySchema,
-  RefreshTokenRequestBody,
-  refreshTokenRequestBodySchema,
   RegisterLocalRequestBody,
   registerLocalRequestBodySchema,
   ResendResetPasswordTokenRequestBody,
@@ -48,7 +46,8 @@ const validateRequestBodyResetPassword = validateRequestBody<ResetPasswordReques
 const validateRequestBodyResendResetPasswordToken = validateRequestBody<ResendResetPasswordTokenRequestBody>(
   resendResetPasswordTokenRequestBodySchema
 );
-const validateRequestBodyRefreshToken = validateRequestBody<RefreshTokenRequestBody>(refreshTokenRequestBodySchema);
+
+// const validateRequestBodyRefreshToken = validateRequestBody<RefreshTokenRequestBody>(refreshTokenRequestBodySchema);
 
 router.post('/register', validateRequestBodyRegister, authLocalController.register.bind(authLocalController));
 router.post('/verify-email', validateRequestBodyVerifyEmail, authLocalController.verifyEmail.bind(authLocalController));

--- a/src/routes/external/cloudinary/folders/index.routes.ts
+++ b/src/routes/external/cloudinary/folders/index.routes.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+import { FolderCloudinaryController } from '../../../../controllers/external/cloudinary/FolderCloudinary.controller';
+
+export const router = Router();
+const folderCloudinaryController = new FolderCloudinaryController();
+
+router.get('/root', folderCloudinaryController.getRoot.bind(folderCloudinaryController));

--- a/src/routes/external/cloudinary/index.routes.ts
+++ b/src/routes/external/cloudinary/index.routes.ts
@@ -1,6 +1,8 @@
 import { Router } from 'express';
 import { router as imagesRouter } from './images/index.routes.js';
+import { router as foldersRouter } from './folders/index.routes.js';
 
 export const router = Router();
 
 router.use('/images', imagesRouter);
+router.use('/folders', foldersRouter);

--- a/src/services/Brand.service.ts
+++ b/src/services/Brand.service.ts
@@ -90,7 +90,6 @@ export class BrandService implements IBrandService {
       limit,
       search
     });
-    console.log(skip);
 
     const totalPage = Math.ceil(totalCount / limit);
     const currentPage = page;

--- a/src/services/external/Cloudinary.service.ts
+++ b/src/services/external/Cloudinary.service.ts
@@ -4,6 +4,7 @@ import { v4 as uuidV4 } from 'uuid';
 import { env } from '../../configs/env.config.js';
 import { CloudinaryFolder } from '../../enums/cloudinaryFolder.enum.js';
 import { CloudinaryUploadError } from '../../errors/CloudinaryUpload.error.js';
+import { GetRootFoldersResponse } from '../../types/cloudinary.type.js';
 import path from 'node:path';
 
 type UploadStreamParams = {
@@ -16,6 +17,7 @@ type UploadStreamParams = {
 
 interface ICloudinaryService {
   uploadStream: (params: UploadStreamParams) => Promise<UploadApiResponse>;
+  getRootFolder: () => Promise<GetRootFoldersResponse>;
 }
 
 export class CloudinaryService implements ICloudinaryService {
@@ -80,5 +82,10 @@ export class CloudinaryService implements ICloudinaryService {
 
   public async delete({ publicId }: { publicId: string }) {
     return await cloudinary.uploader.destroy(publicId);
+  }
+
+  public async getRootFolder(): Promise<GetRootFoldersResponse> {
+    const result = await cloudinary.api.root_folders();
+    return result;
   }
 }

--- a/src/types/cloudinary.type.ts
+++ b/src/types/cloudinary.type.ts
@@ -1,0 +1,13 @@
+import { AdminApiBaseResponse, AdminApiPaginationResponse } from 'cloudinary';
+
+type Folder = {
+  name: string;
+  path: string;
+  external_id: string;
+};
+
+export type GetRootFoldersResponse = AdminApiBaseResponse &
+  AdminApiPaginationResponse & {
+    folders: Folder[];
+    total_count: number;
+  };


### PR DESCRIPTION
Build an API that retrieves the list of all top-level folders (root folders) stored in your Cloudinary account. This feature allows the frontend (e.g., admin dashboard) to browse folders and organize files by category.

Closes #244