### PR TITLE
feat(src): implement api get all file resources

### DIFF
--- a/src/controllers/external/cloudinary/FileCloudinary.controller.ts
+++ b/src/controllers/external/cloudinary/FileCloudinary.controller.ts
@@ -1,0 +1,40 @@
+import { sendSuccessResponse } from './../../../utils/responses.util.js';
+import { CloudinaryService } from './../../../services/external/Cloudinary.service.js';
+import { NextFunction, Request, Response } from 'express';
+import { StatusCodes } from 'http-status-codes';
+import { FileCloudinaryResponseDTO } from '../../../dto/response/external/cloudinary/file/index.dto.js';
+
+type GetAllFilesRequestType = Request<
+  unknown,
+  unknown,
+  unknown,
+  {
+    nextCursor?: string;
+  }
+>;
+
+interface IFileCloudinaryController {
+  getAllFileResources: (request: GetAllFilesRequestType, response: Response, next: NextFunction) => Promise<void>;
+}
+
+export class FileCloudinaryController implements IFileCloudinaryController {
+  constructor() {}
+
+  public async getAllFileResources(request: GetAllFilesRequestType, response: Response): Promise<void> {
+    const { nextCursor = null } = request.query;
+    const cloudinaryService = new CloudinaryService('root');
+    const result = await cloudinaryService.getAllFilesResources({ nextCursor });
+
+    const { data, metadata } = FileCloudinaryResponseDTO.getAllFileResource(result);
+
+    sendSuccessResponse<typeof data, typeof metadata>({
+      response,
+      content: {
+        statusCode: StatusCodes.OK,
+        message: 'Get all file resources success',
+        data,
+        metadata
+      }
+    });
+  }
+}

--- a/src/dto/response/external/cloudinary/file/commons.dto.ts
+++ b/src/dto/response/external/cloudinary/file/commons.dto.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const fileResourceDTOSchema = z.object({
+  assetId: z.string(),
+  publicId: z.string(),
+  format: z.string(),
+  resourceType: z.string(),
+  createdAt: z.string(),
+  bytes: z.number(),
+  assetFolder: z.string(),
+  displayName: z.string()
+});
+
+export const metadataFileSchema = z.object({
+  nextCursor: z.string().nullable(),
+  rateLimitAllowed: z.number(),
+  rateLimitResetAt: z.string(),
+  rateLimitRemaining: z.number()
+});
+
+export type FileResourceDTO = z.infer<typeof fileResourceDTOSchema>;
+export type MetadataFileSchema = z.infer<typeof metadataFileSchema>;

--- a/src/dto/response/external/cloudinary/file/getAllFileResources.dto.ts
+++ b/src/dto/response/external/cloudinary/file/getAllFileResources.dto.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import { fileResourceDTOSchema, metadataFileSchema } from './commons.dto.js';
+
+export const getAllFileResourcesDTO = z.object({
+  data: z.array(fileResourceDTOSchema),
+  metadata: metadataFileSchema
+});
+
+export type GetAllFileResourcesDTO = z.infer<typeof getAllFileResourcesDTO>;

--- a/src/dto/response/external/cloudinary/file/index.dto.ts
+++ b/src/dto/response/external/cloudinary/file/index.dto.ts
@@ -1,0 +1,36 @@
+import { GetAllFilesResourceResponse } from './../../../../../types/cloudinary.type.js';
+import { getAllFileResourcesDTO, GetAllFileResourcesDTO } from './getAllFileResources.dto.js';
+
+export class FileCloudinaryResponseDTO {
+  constructor() {}
+
+  static getAllFileResource(data: GetAllFilesResourceResponse) {
+    const fileResources: GetAllFileResourcesDTO['data'] = data.resources.map((fileResource) => {
+      const createdAtFormat = new Date(fileResource.created_at).toISOString();
+      return {
+        assetId: fileResource.asset_id,
+        assetFolder: fileResource.asset_folder,
+        format: fileResource.format,
+        resourceType: fileResource.resource_type,
+        createdAt: createdAtFormat,
+        bytes: fileResource.bytes,
+        publicId: fileResource.public_id,
+        displayName: fileResource.display_name
+      };
+    });
+
+    const resentAtFormat = new Date(data.rate_limit_reset_at!).toISOString();
+
+    const candidate: GetAllFileResourcesDTO = {
+      data: fileResources,
+      metadata: {
+        nextCursor: data.next_cursor! || null,
+        rateLimitAllowed: data.rate_limit_allowed!,
+        rateLimitRemaining: data.rate_limit_remaining!,
+        rateLimitResetAt: resentAtFormat
+      }
+    };
+
+    return getAllFileResourcesDTO.parse(candidate);
+  }
+}

--- a/src/routes/external/cloudinary/files/index.routes.ts
+++ b/src/routes/external/cloudinary/files/index.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { FileCloudinaryController } from '../../../../controllers/external/cloudinary/FileCloudinary.controller.js';
+
+export const router = Router();
+
+const fileCloudinaryController = new FileCloudinaryController();
+
+router.get('/', fileCloudinaryController.getAllFileResources.bind(fileCloudinaryController));

--- a/src/routes/external/cloudinary/index.routes.ts
+++ b/src/routes/external/cloudinary/index.routes.ts
@@ -1,8 +1,10 @@
 import { Router } from 'express';
 import { router as imagesRouter } from './images/index.routes.js';
 import { router as foldersRouter } from './folders/index.routes.js';
+import { router as filesRouter } from './files/index.routes.js';
 
 export const router = Router();
 
 router.use('/images', imagesRouter);
 router.use('/folders', foldersRouter);
+router.use('/files', filesRouter);

--- a/src/services/external/Cloudinary.service.ts
+++ b/src/services/external/Cloudinary.service.ts
@@ -4,7 +4,11 @@ import { v4 as uuidV4 } from 'uuid';
 import { env } from '../../configs/env.config.js';
 import { CloudinaryFolder } from '../../enums/cloudinaryFolder.enum.js';
 import { CloudinaryUploadError } from '../../errors/CloudinaryUpload.error.js';
-import { GetRootFoldersResponse, GetSubFoldersResponse } from '../../types/cloudinary.type.js';
+import {
+  GetAllFilesResourceResponse,
+  GetRootFoldersResponse,
+  GetSubFoldersResponse
+} from '../../types/cloudinary.type.js';
 import path from 'node:path';
 
 type UploadStreamParams = {
@@ -15,10 +19,16 @@ type UploadStreamParams = {
   isOverwrite?: boolean;
 };
 
+type GetAllFilesResourcesParams = {
+  nextCursor: string | null;
+};
+
 interface ICloudinaryService {
   uploadStream: (params: UploadStreamParams) => Promise<UploadApiResponse>;
   getRootFolder: () => Promise<GetRootFoldersResponse>;
   getSubFolder: () => Promise<GetSubFoldersResponse>;
+
+  getAllFilesResources: (params: GetAllFilesResourcesParams) => Promise<GetAllFilesResourceResponse>;
 }
 
 export class CloudinaryService implements ICloudinaryService {
@@ -92,6 +102,12 @@ export class CloudinaryService implements ICloudinaryService {
 
   public async getSubFolder(): Promise<GetSubFoldersResponse> {
     const result = await cloudinary.api.sub_folders(this._folder);
+    return result;
+  }
+
+  public async getAllFilesResources({ nextCursor }: GetAllFilesResourcesParams): Promise<GetAllFilesResourceResponse> {
+    console.log(nextCursor);
+    const result = await cloudinary.api.resources({ next_cursor: nextCursor });
     return result;
   }
 }

--- a/src/types/cloudinary.type.ts
+++ b/src/types/cloudinary.type.ts
@@ -6,6 +6,23 @@ type Folder = {
   external_id: string;
 };
 
+export type FileResource = {
+  asset_id: string;
+  public_id: string;
+  format: string;
+  version: number;
+  resource_type: string;
+  type: string;
+  created_at: string;
+  bytes: number;
+  width: number;
+  height: number;
+  asset_folder: string;
+  display_name: string;
+  url: string;
+  secure_url: string;
+};
+
 export type GetRootFoldersResponse = AdminApiBaseResponse &
   AdminApiPaginationResponse & {
     folders: Folder[];
@@ -16,4 +33,9 @@ export type GetSubFoldersResponse = AdminApiBaseResponse &
   AdminApiPaginationResponse & {
     folders: Folder[];
     total_count: number;
+  };
+
+export type GetAllFilesResourceResponse = AdminApiBaseResponse &
+  AdminApiPaginationResponse & {
+    resources: FileResource[];
   };


### PR DESCRIPTION
Implement an API endpoint to fetch all image files stored in Cloudinary, optionally filtered by folder path. This allows the frontend to display and manage all images regardless of their folder or to get a complete view of a specific folder.

Closes #248