### PR TITLE
feat(src): implement Api Shrink Image From URL

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import { router as systemRouter } from './routes/system/index.routes.js';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import { router as utilsRouter } from './routes/utils/index.routes.js';
+import { router as tinyPNGRouter } from './routes/external/tinyPNG/index.routes.js';
 
 const app = express();
 
@@ -38,6 +39,7 @@ app.use('/categories', categoryRouter);
 app.use('/products', productRouter);
 app.use('/system', systemRouter);
 app.use('/utils', utilsRouter);
+app.use('/tinyPNG', tinyPNGRouter);
 
 app.use(ErrorMiddlewareHandler.handler.bind(ErrorMiddlewareHandler));
 

--- a/src/configs/env.config.ts
+++ b/src/configs/env.config.ts
@@ -72,5 +72,8 @@ export const env = {
     NAME: process.env.CLOUDINARY_NAME,
     KEY: process.env.CLOUDINARY_KEY,
     SECRET: process.env.CLOUDINARY_SECRET
+  },
+  tinyPNG: {
+    API_KEY: process.env.TINY_PNG_API_KEY
   }
 };

--- a/src/controllers/external/cloudinary/FileCloudinary.controller.ts
+++ b/src/controllers/external/cloudinary/FileCloudinary.controller.ts
@@ -99,6 +99,7 @@ export class FileCloudinaryController implements IFileCloudinaryController {
       isOverwrite: false
     });
 
+    //TODO: Implement DTO response
     // const { data } = FileCloudinaryResponseDTO.uploadFileResources(result);
 
     sendSuccessResponse<typeof result>({
@@ -119,6 +120,8 @@ export class FileCloudinaryController implements IFileCloudinaryController {
 
     const cloudinaryService = new CloudinaryService(folderPath);
     const result = await cloudinaryService.uploadFileResourcesFromLink({ link, folderPath, filename });
+
+    //TODO: Implement DTO response
 
     sendSuccessResponse<typeof result>({
       response,

--- a/src/controllers/external/tinyPNG/CompressingImage.controller.ts
+++ b/src/controllers/external/tinyPNG/CompressingImage.controller.ts
@@ -1,0 +1,35 @@
+import { sendSuccessResponse } from '../../../utils/responses.util.js';
+import { TinyPNGService } from '../../../services/external/TinyPNG.service.js';
+import { Request, Response } from 'express';
+import { CompressingImageFromUrlDTO } from '../../../dto/request/external/tinyPNG/compressingImage/fromURL.dto.js';
+import { TinyPNGCompressingImageRequestDTO } from '../../../dto/request/external/tinyPNG/compressingImage/index.dto.js';
+import { StatusCodes } from 'http-status-codes';
+import { TinyPNGCompressingImageResponseDTO } from '../../../dto/response/external/tinyPNG/index.dto.js';
+
+type FromURLRequestType = Request<unknown, unknown, CompressingImageFromUrlDTO>;
+
+interface ICompressingImageTinyPNGController {
+  fromURL: (request: FromURLRequestType, response: Response) => Promise<void>;
+}
+
+export class CompressingImageTinyPNGController implements ICompressingImageTinyPNGController {
+  private readonly tinyPNGService: TinyPNGService = new TinyPNGService();
+
+  constructor() {}
+
+  public async fromURL(request: FromURLRequestType, response: Response): Promise<void> {
+    const { url } = TinyPNGCompressingImageRequestDTO.fromURL(request.body);
+    const data = await this.tinyPNGService.compressingImageFromURL({ url });
+
+    const result = TinyPNGCompressingImageResponseDTO.fromURL(data);
+
+    sendSuccessResponse<typeof result>({
+      response,
+      content: {
+        statusCode: StatusCodes.OK,
+        message: 'Compressing image from URL success',
+        data: result
+      }
+    });
+  }
+}

--- a/src/dto/request/external/tinyPNG/compressingImage/fromURL.dto.ts
+++ b/src/dto/request/external/tinyPNG/compressingImage/fromURL.dto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const compressingImageFromUrlDTO = z.object({
+  url: z.string({ required_error: 'URL is required' })
+});
+
+export type CompressingImageFromUrlDTO = z.infer<typeof compressingImageFromUrlDTO>;

--- a/src/dto/request/external/tinyPNG/compressingImage/index.dto.ts
+++ b/src/dto/request/external/tinyPNG/compressingImage/index.dto.ts
@@ -1,0 +1,9 @@
+import { compressingImageFromUrlDTO, CompressingImageFromUrlDTO } from './fromURL.dto.js';
+
+export class TinyPNGCompressingImageRequestDTO {
+  constructor() {}
+
+  static fromURL(data: CompressingImageFromUrlDTO) {
+    return compressingImageFromUrlDTO.parse(data);
+  }
+}

--- a/src/dto/response/external/tinyPNG/fromURL.dto.ts
+++ b/src/dto/response/external/tinyPNG/fromURL.dto.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const compressingImageFromUrlDTO = z.object({
+  input: z.object({
+    size: z.number(),
+    type: z.string()
+  }),
+  output: z.object({
+    size: z.number(),
+    type: z.string(),
+    width: z.number(),
+    height: z.number(),
+    ratio: z.number(),
+    url: z.string()
+  })
+});
+
+export type CompressingImageFromUrlDTO = z.infer<typeof compressingImageFromUrlDTO>;

--- a/src/dto/response/external/tinyPNG/index.dto.ts
+++ b/src/dto/response/external/tinyPNG/index.dto.ts
@@ -1,0 +1,24 @@
+import { compressingImageFromUrlDTO, CompressingImageFromUrlDTO } from './fromURL.dto.js';
+import { TinyPNGShrinkImageResponse } from '../../../../types/tinyPNG.type.js';
+
+export class TinyPNGCompressingImageResponseDTO {
+  constructor() {}
+
+  static fromURL(data: TinyPNGShrinkImageResponse) {
+    const candidate: CompressingImageFromUrlDTO = {
+      input: {
+        size: data.input.size,
+        type: data.input.type
+      },
+      output: {
+        size: data.output.size,
+        type: data.output.type,
+        width: data.output.width,
+        height: data.output.height,
+        ratio: data.output.ratio,
+        url: data.output.url
+      }
+    };
+    return compressingImageFromUrlDTO.parse(candidate);
+  }
+}

--- a/src/routes/external/tinyPNG/index.routes.ts
+++ b/src/routes/external/tinyPNG/index.routes.ts
@@ -1,0 +1,6 @@
+import { router as shrinkRouter } from './shrink.routes.js';
+import { Router } from 'express';
+
+export const router = Router();
+
+router.use('/shrink', shrinkRouter);

--- a/src/routes/external/tinyPNG/shrink.routes.ts
+++ b/src/routes/external/tinyPNG/shrink.routes.ts
@@ -1,0 +1,19 @@
+import { validateRequestBody } from './../../../middleware/validateRequestBody.middleware.js';
+import { Router } from 'express';
+import { CompressingImageTinyPNGController } from '../../../controllers/external/tinyPNG/CompressingImage.controller.js';
+import {
+  compressingImageFromUrlDTO,
+  CompressingImageFromUrlDTO
+} from '../../../dto/request/external/tinyPNG/compressingImage/fromURL.dto.js';
+
+export const router = Router();
+
+const compressingImageTinyPNGController = new CompressingImageTinyPNGController();
+
+const validateRequestBodyShrinkFromURL = validateRequestBody<CompressingImageFromUrlDTO>(compressingImageFromUrlDTO);
+
+router.post(
+  '/from-url',
+  validateRequestBodyShrinkFromURL,
+  compressingImageTinyPNGController.fromURL.bind(compressingImageTinyPNGController)
+);

--- a/src/services/external/TinyPNG.service.ts
+++ b/src/services/external/TinyPNG.service.ts
@@ -1,0 +1,31 @@
+import { TinyPNGShrinkImageResponse } from './../../types/tinyPNG.type.js';
+import { env } from '../../configs/env.config.js';
+type CompressingImageFromURLParams = {
+  url: string;
+};
+
+interface ITinyPNGService {
+  compressingImageFromURL: (params: CompressingImageFromURLParams) => Promise<TinyPNGShrinkImageResponse>;
+}
+
+export class TinyPNGService implements ITinyPNGService {
+  constructor() {}
+
+  public async compressingImageFromURL({ url }: CompressingImageFromURLParams): Promise<TinyPNGShrinkImageResponse> {
+    const response = await fetch('https://api.tinify.com/shrink', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Basic ${env.tinyPNG.API_KEY}`
+      },
+      body: JSON.stringify({
+        source: {
+          url
+        }
+      })
+    });
+
+    const data = await response.json();
+    return data;
+  }
+}

--- a/src/types/tinyPNG.type.ts
+++ b/src/types/tinyPNG.type.ts
@@ -1,0 +1,14 @@
+export type TinyPNGShrinkImageResponse = {
+  input: {
+    size: number;
+    type: string;
+  };
+  output: {
+    size: number;
+    type: string;
+    width: number;
+    height: number;
+    ratio: number;
+    url: string;
+  };
+};


### PR DESCRIPTION
This commit adds a new API endpoint that enables image compression directly from a given image URL using the TinyPNG service.

Closes #254